### PR TITLE
Return value from ShopifyRefund.perform() in main task run()

### DIFF
--- a/shopify_refund.js
+++ b/shopify_refund.js
@@ -5,7 +5,7 @@ module.exports = {
   description:
     "This action uses the Firmhouse API to refund a payment based on a cancelled or refunded Shopify order",
   key: "shopify_refund",
-  version: "0.0.47",
+  version: "0.0.48",
   type: "action",
   props: {
     body: {


### PR DESCRIPTION
We call `ShopifyRefund.perform()` in our main action `run()` task, but we don't re-return its return value. So if the `perform()` function returns something (early), it doesn't bubble up to the top-level workflow action return. This PR adds the return statement so that the return value always bubbles up to the action output.

Closes PROD-421